### PR TITLE
Extended the FuncApp template and added vnet template

### DIFF
--- a/IaC/main.bicep
+++ b/IaC/main.bicep
@@ -1,4 +1,7 @@
 param region string = 'westeurope'
+var storageAccName = '${uniqueString(rg.id)}azfunctions'
+var initFuncSubnetName = 'AzureFuncDelegatedSubnet'
+var vnetName = 'virtualNetwork'
 
 targetScope = 'subscription'
 
@@ -11,7 +14,41 @@ module initAzureFunction 'FuncApp.bicep' = {
   scope: resourceGroup('CalendarSync')
   name: 'Initialisation-Function'
   params: {
+    storageAccountName: storageAccName
     appName: 'InitFunc'
-    location: 'westeurope'
+    location: region
+    vnetName: vnetName
+    subnetName: initFuncSubnetName
+  }
+}
+
+module vNet 'vNet.bicep' = {
+  scope: rg
+  name: vnetName
+  params: {
+    name: vnetName
+    vnetAddressPrefix: '10.100.0.0/16'
+    storageAccount: initAzureFunction.outputs.storageAccount
+    location: region
+    subnets: [
+      {
+        name: initFuncSubnetName
+        addressPrefix: '10.100.0.0/24'
+        delegations: [
+          {
+            name: 'AzureFunc'
+            properties: {
+              serviceName: 'Microsoft.Web/serverFarms'
+            }
+          }
+        ]
+      }
+      {
+        name: 'StorageAccountDelegatedSubnet'
+        addressPrefix: '10.100.1.0/24'
+        privateLinkServiceNetworkPolicies: 'Enabled'
+        privateEndpointNetworkPolicies: 'Disabled'
+      }
+    ]
   }
 }

--- a/IaC/main.bicep
+++ b/IaC/main.bicep
@@ -44,7 +44,7 @@ module vNet 'vNet.bicep' = {
         ]
       }
       {
-        name: 'StorageAccountDelegatedSubnet'
+        name: storageAccName
         addressPrefix: '10.100.1.0/24'
         privateLinkServiceNetworkPolicies: 'Enabled'
         privateEndpointNetworkPolicies: 'Disabled'

--- a/IaC/vNet.bicep
+++ b/IaC/vNet.bicep
@@ -16,10 +16,10 @@ param privateStorageBlobDnsZoneName string = 'BlobDnsZone'
 param privateStorageQueueDnsZoneName string = 'QueueDnsZone'
 param privateStorageTableDnsZoneName string = 'TableDnsZone'
 
-param virtualNetworkLinksSuffixFileStorageName string = ''
-param virtualNetworkLinksSuffixBlobStorageName string = ''
-param virtualNetworkLinksSuffixQueueStorageName string = ''
-param virtualNetworkLinksSuffixTableStorageName string = ''
+param vNetLinkFileStorageName string = '${privateStorageFileDnsZoneName}-link'
+param vNetLinkBlobStorageName string = '${privateStorageBlobDnsZoneName}-link'
+param vNetLinkQueueStorageName string = '${privateStorageQueueDnsZoneName}-link'
+param vNetLinkTableStorageName string = '${privateStorageTableDnsZoneName}-link'
 
 @description('id and name')
 param storageAccount object
@@ -86,7 +86,7 @@ resource privateStorageTableDnsZone 'Microsoft.Network/privateDnsZones@2020-06-0
 
 resource privateStorageFileDnsZoneName_virtualNetworkLinksSuffixFileStorage 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
   parent: privateStorageFileDnsZone
-  name: virtualNetworkLinksSuffixFileStorageName
+  name: vNetLinkFileStorageName
   location: 'global'
   properties: {
     registrationEnabled: false
@@ -98,7 +98,7 @@ resource privateStorageFileDnsZoneName_virtualNetworkLinksSuffixFileStorage 'Mic
 
 resource privateStorageBlobDnsZoneName_virtualNetworkLinksSuffixBlobStorage 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
   parent: privateStorageBlobDnsZone
-  name: virtualNetworkLinksSuffixBlobStorageName
+  name: vNetLinkBlobStorageName
   location: 'global'
   properties: {
     registrationEnabled: false
@@ -110,7 +110,7 @@ resource privateStorageBlobDnsZoneName_virtualNetworkLinksSuffixBlobStorage 'Mic
 
 resource privateStorageQueueDnsZoneName_virtualNetworkLinksSuffixQueueStorage 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
   parent: privateStorageQueueDnsZone
-  name: virtualNetworkLinksSuffixQueueStorageName
+  name: vNetLinkQueueStorageName
   location: 'global'
   properties: {
     registrationEnabled: false
@@ -122,7 +122,7 @@ resource privateStorageQueueDnsZoneName_virtualNetworkLinksSuffixQueueStorage 'M
 
 resource privateStorageTableDnsZoneName_virtualNetworkLinksSuffixTableStorage 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
   parent: privateStorageTableDnsZone
-  name: virtualNetworkLinksSuffixTableStorageName
+  name: vNetLinkTableStorageName
   location: 'global'
   properties: {
     registrationEnabled: false

--- a/IaC/vNet.bicep
+++ b/IaC/vNet.bicep
@@ -1,0 +1,277 @@
+param name string
+
+param location string = resourceGroup().location
+
+@description('Address prefix')
+param vnetAddressPrefix string
+
+@description('IP addresses of DNS servers to use')
+param dnsServers array = []
+
+@description('Name, addressPrefix, delegations, serviceEndpoints, routeTable, natGateway, networkSecurityGroup, privateEndpointNetworkPolicies and privateLinkServiceNetworkPolicies of the subnets')
+param subnets array
+
+param privateStorageFileDnsZoneName string = 'StorageFileDnsZone'
+param privateStorageBlobDnsZoneName string = 'BlobDnsZone'
+param privateStorageQueueDnsZoneName string = 'QueueDnsZone'
+param privateStorageTableDnsZoneName string = 'TableDnsZone'
+
+param virtualNetworkLinksSuffixFileStorageName string = ''
+param virtualNetworkLinksSuffixBlobStorageName string = ''
+param virtualNetworkLinksSuffixQueueStorageName string = ''
+param virtualNetworkLinksSuffixTableStorageName string = ''
+
+@description('id and name')
+param storageAccount object
+
+resource vnet 'Microsoft.Network/virtualNetworks@2020-05-01' = {
+  name: name
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+    dhcpOptions: {
+      dnsServers: dnsServers
+    }
+    subnets: [for item in subnets: {
+      name: item.name
+      properties: {
+        addressPrefix: item.addressPrefix
+        delegations: item.delegations
+        serviceEndpoints: item.serviceEndpoints
+        routeTable: ((!empty(item.routeTable)) ? json('{"id":"${resourceId('Microsoft.Network/routeTables', item.routeTable)}"}') : json('null'))
+        natGateway: ((!empty(item.natGateway)) ? json('{"id":"${resourceId('Microsoft.Network/natGateways', item.natGateway)}"}') : json('null'))
+        networkSecurityGroup: ((!empty(item.networkSecurityGroup)) ? json('{"id":"${resourceId('Microsoft.Network/networkSecurityGroups', item.networkSecurityGroup)}"}') : json('null'))
+        privateEndpointNetworkPolicies: item.privateEndpointNetworkPolicies
+        privateLinkServiceNetworkPolicies: item.privateLinkServiceNetworkPolicies
+      }
+    }]
+  }
+}
+
+resource privateStorageFileDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: privateStorageFileDnsZoneName
+  location: 'global'
+  dependsOn: [
+    vnet
+  ]
+}
+
+resource privateStorageBlobDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: privateStorageBlobDnsZoneName
+  location: 'global'
+  dependsOn: [
+    vnet
+  ]
+}
+
+resource privateStorageQueueDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: privateStorageQueueDnsZoneName
+  location: 'global'
+  dependsOn: [
+    vnet
+  ]
+}
+
+resource privateStorageTableDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: privateStorageTableDnsZoneName
+  location: 'global'
+  dependsOn: [
+    vnet
+  ]
+}
+
+resource privateStorageFileDnsZoneName_virtualNetworkLinksSuffixFileStorage 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: privateStorageFileDnsZone
+  name: virtualNetworkLinksSuffixFileStorageName
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnet.id
+    }
+  }
+}
+
+resource privateStorageBlobDnsZoneName_virtualNetworkLinksSuffixBlobStorage 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: privateStorageBlobDnsZone
+  name: virtualNetworkLinksSuffixBlobStorageName
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnet.id
+    }
+  }
+}
+
+resource privateStorageQueueDnsZoneName_virtualNetworkLinksSuffixQueueStorage 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: privateStorageQueueDnsZone
+  name: virtualNetworkLinksSuffixQueueStorageName
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnet.id
+    }
+  }
+}
+
+resource privateStorageTableDnsZoneName_virtualNetworkLinksSuffixTableStorage 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: privateStorageTableDnsZone
+  name: virtualNetworkLinksSuffixTableStorageName
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnet.id
+    }
+  }
+}
+
+resource privateEndpointFileStorage 'Microsoft.Network/privateEndpoints@2020-06-01' = {
+  name: '${storageAccount.name}-file-private-endpoint'
+  location: location
+  properties: {
+    subnet: {
+      id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, storageAccount.name)
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'MyStorageQueuePrivateLinkConnection'
+        properties: {
+          privateLinkServiceId: storageAccount.id
+          groupIds: [
+            'file'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource privateEndpointBlobStorage 'Microsoft.Network/privateEndpoints@2020-06-01' = {
+  name: '${storageAccount.name}-blob-private-endpoint'
+  location: location
+  properties: {
+    subnet: {
+      id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, storageAccount.name)
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'MyStorageQueuePrivateLinkConnection'
+        properties: {
+          privateLinkServiceId: storageAccount.id
+          groupIds: [
+            'blob'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource privateEndpointQueueStorage 'Microsoft.Network/privateEndpoints@2020-06-01' = {
+  name: '${storageAccount.name}-queue-private-endpoint'
+  location: location
+  properties: {
+    subnet: {
+      id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, storageAccount.name)
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'MyStorageQueuePrivateLinkConnection'
+        properties: {
+          privateLinkServiceId: storageAccount.id
+          groupIds: [
+            'queue'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource privateEndpointTableStorage 'Microsoft.Network/privateEndpoints@2020-06-01' = {
+  name: '${storageAccount.name}-table-private-endpoint'
+  location: location
+  properties: {
+    subnet: {
+      id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, storageAccount.name)
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'MyStorageQueuePrivateLinkConnection'
+        properties: {
+          privateLinkServiceId: storageAccount.id
+          groupIds: [
+            'table'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource privateEndpointFileStorageName_default 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-06-01' = {
+  parent: privateEndpointFileStorage
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config1'
+        properties: {
+          privateDnsZoneId: privateStorageFileDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+resource privateEndpointBlobStorageName_default 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-06-01' = {
+  parent: privateEndpointBlobStorage
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config1'
+        properties: {
+          privateDnsZoneId: privateStorageBlobDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+resource privateEndpointQueueStorageName_default 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-06-01' = {
+  parent: privateEndpointQueueStorage
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config1'
+        properties: {
+          privateDnsZoneId: privateStorageQueueDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+resource privateEndpointTableStorageName_default 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-06-01' = {
+  parent: privateEndpointTableStorage
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config1'
+        properties: {
+          privateDnsZoneId: privateStorageTableDnsZone.id
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Extended FuncApp template
The FuncApp template now also creates a file share and a network configuration.
This template now outputs the id and name of the created storage account.

### ✨vNet template✨
Added new template that creates a new vnet resource with the following subresources:
1. 4 DNS zones (one zone per storage type [File/Blob/Queue/Table]) with their own virtualNetworkLinks (to link the DNS zones to the right vNet)
2. 4 private endpoints, one endpoint per storage type (these live inside the storage account subnet)
3. 4 DNS zone groups, one group per storage type